### PR TITLE
Some improvement suggestions for chainmail.

### DIFF
--- a/lib/quasi-chainmail.js
+++ b/lib/quasi-chainmail.js
@@ -72,9 +72,7 @@ memberDecl <- paramDecl _SEMI / typeDecl;
 INTERFACE <- "interface" _WS;
 interfaceDecl <- INTERFACE type extends? LBRACE methodDecl* RBRACE
   ${(_, itype, ext, _2, methods, _3) =>
-   ext.length === 0
-     ? ['interface', itype, methods]
-     : ['interface', itype, [ 'extends', ext[0]], methods]};
+  ['interface', itype, deopt(ext), methods]};
 
 EXTENDS <- "extends" _WS;
 extends <- EXTENDS LPAREN type**_COMMA RPAREN
@@ -86,10 +84,7 @@ paramDecls <- LPAREN paramDecl**_COMMA RPAREN
 resultDecls <- RARROW LPAREN resultDecl**_COMMA RPAREN
   ${(_, _2, decls, _3) => decls};
 methodDecl <- IDENT methodTypeParams? paramDecls resultDecls? _SEMI
-  ${(id, tparams, pdecls, rdecls, _) => 
-    tparams.length === 0
-      ? ['method', id, pdecls, deopt(rdecls)]
-      : ['method', id, ['typeparams', tparams[0]], pdecls, deopt(rdecls)]};
+  ${(id, tparams, pdecls, rdecls, _) => ['method', id, deopt(tparams), pdecls, deopt(rdecls)]};
 
 LBRACKET <- "[" _WS;
 RBRACKET <- "]" _WS;

--- a/lib/quasi-chainmail.js
+++ b/lib/quasi-chainmail.js
@@ -65,14 +65,16 @@ enumDecl <- ENUM type LBRACE (IDENT _SEMI)* RBRACE
 STRUCT <- "struct" _WS;
 structDecl <- STRUCT type LBRACE memberDecl* RBRACE
   ${(_, stype, _2, members, _3) =>
-  ['struct', stype[1], stype[2], members]};
+  ['struct', stype, members]};
 
 memberDecl <- paramDecl _SEMI / typeDecl;
 
 INTERFACE <- "interface" _WS;
 interfaceDecl <- INTERFACE type extends? LBRACE methodDecl* RBRACE
   ${(_, itype, ext, _2, methods, _3) =>
-  ['interface', itype, deopt(ext), methods]};
+   ext.length === 0
+     ? ['interface', itype, methods]
+     : ['interface', itype, [ 'extends', ext[0]], methods]};
 
 EXTENDS <- "extends" _WS;
 extends <- EXTENDS LPAREN type**_COMMA RPAREN
@@ -84,7 +86,10 @@ paramDecls <- LPAREN paramDecl**_COMMA RPAREN
 resultDecls <- RARROW LPAREN resultDecl**_COMMA RPAREN
   ${(_, _2, decls, _3) => decls};
 methodDecl <- IDENT methodTypeParams? paramDecls resultDecls? _SEMI
-  ${(id, tparams, pdecls, rdecls, _) => ['method', id, deopt(tparams), pdecls, deopt(rdecls)]};
+  ${(id, tparams, pdecls, rdecls, _) => 
+    tparams.length === 0
+      ? ['method', id, pdecls, deopt(rdecls)]
+      : ['method', id, ['typeparams', tparams[0]], pdecls, deopt(rdecls)]};
 
 LBRACKET <- "[" _WS;
 RBRACKET <- "]" _WS;

--- a/lib/quasi-chainmail.js
+++ b/lib/quasi-chainmail.js
@@ -30,7 +30,7 @@ const makeChainmail = insulate(peg => {
   const { FAIL, HOLE, SKIP } = peg;
   return peg`
 # start production
-start <- _WS typeDecl**(_SEMI*) _EOF  ${v => (..._a) => v};
+start <- _WS typeDecl* _EOF  ${v => (..._a) => v};
 
 typeDecl <- enumDecl / structDecl / interfaceDecl / constDecl;
 


### PR DESCRIPTION
The struct production was broken. I don't remember
why we were destructuring stype.

I modified the extends clauses of interfaces, and the
type parameters of methods to only print them when present.